### PR TITLE
Add support for Python 3.9, drop EOL 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install -e .
 script:

--- a/p_tqdm/p_tqdm.py
+++ b/p_tqdm/p_tqdm.py
@@ -46,8 +46,7 @@ def _parallel(ordered: bool, function: Callable, *iterables: Iterable, **kwargs:
     pool = Pool(num_cpus)
     map_func = getattr(pool, map_type)
 
-    for item in tqdm(map_func(function, *iterables), total=length, **kwargs):
-        yield item
+    yield from tqdm(map_func(function, *iterables), total=length, **kwargs)
 
     pool.clear()
 
@@ -106,8 +105,7 @@ def _sequential(function: Callable, *iterables: Iterable, **kwargs: Any) -> Gene
     length = min(len(iterable) for iterable in iterables if isinstance(iterable, Sized))
 
     # Create sequential generator
-    for item in tqdm(map(function, *iterables), total=length, **kwargs):
-        yield item
+    yield from tqdm(map(function, *iterables), total=length, **kwargs)
 
 
 def t_map(function: Callable, *iterables: Iterable, **kwargs: Any) -> List[Any]:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     install_requires=[
         'tqdm',
         'pathos',
-        'six'
     ],
     test_suite='nose.collector',
     tests_require=['nose'],

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     ],
     test_suite='nose.collector',
     tests_require=['nose'],
+    python_requires='>=3.6',
     classifiers=[
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     tests_require=['nose'],
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3 :: Only',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,7 +18,7 @@ def add_3(a, b, c=0):
 
 class Test_p_map(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(Test_p_map, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.func = p_map
         self.generator = False
         self.ordered = True


### PR DESCRIPTION
Here's the pip installs for p_tqdm from PyPI for December 2020:

| category | percent | downloads |
|----------|--------:|----------:|
| 3.6      |  48.25% |     1,598 |
| 3.7      |  37.71% |     1,249 |
| 3.8      |  10.24% |       339 |
| null     |   2.63% |        87 |
| 3.9      |   0.72% |        24 |
| 2.7      |   0.24% |         8 |
| 3.5      |   0.21% |         7 |
| Total    |         |     3,312 |

Source: `pip install -U pypistats && pypistats python_minor p_tqdm --last-month`


Also:
* Declare support for and test Python 3.9, released October 2020
* Remove unused six dependency
* Add `python_requires` to help pip
* Upgrade Python syntax with https://github.com/asottile/pyupgrade `--py36-plus`

