### PR TITLE
modified for newer version of collections

### DIFF
--- a/p_tqdm/p_tqdm.py
+++ b/p_tqdm/p_tqdm.py
@@ -8,7 +8,7 @@ t_map: Performs a sequential map.
 t_imap: Returns an iterator for a sequential map.
 """
 
-from collections import Sized
+from collections.abc import Sized
 from typing import Any, Callable, Generator, Iterable, List
 
 from pathos.helpers import cpu_count


### PR DESCRIPTION
I got this error

```
from p_tqdm import p_map
  File "/home/jga/.pyenv/versions/amas/lib/python3.10/site-packages/p_tqdm/__init__.py", line 1, in <module>
    from p_tqdm.p_tqdm import p_map, p_imap, p_umap, p_uimap, t_map, t_imap
  File "/home/jga/.pyenv/versions/amas/lib/python3.10/site-packages/p_tqdm/p_tqdm.py", line 11, in <module>
    from collections import Sized
ImportError: cannot import name 'Sized' from 'collections' (/home/jga/.pyenv/versions/3.10.0/lib/python3.10/collections/__init__.py)
``` 

Which is fixed with this PR - also it seems like the "new" way to import things from collections.