### PR TITLE
Fix "import Sized" in p_tqdm.py

### DIFF
--- a/p_tqdm/p_tqdm.py
+++ b/p_tqdm/p_tqdm.py
@@ -8,7 +8,7 @@ t_map: Performs a sequential map.
 t_imap: Returns an iterator for a sequential map.
 """
 
-from collections import Sized
+from collections.abc import Sized
 from typing import Any, Callable, Generator, Iterable, List
 
 from pathos.helpers import cpu_count


### PR DESCRIPTION
In p_tqdm.py, line 11: 
the Sized can no longer be imported from collections in python3.10, collections.abc should be used instead.