### PR TITLE
Allow overriding tqdm function used

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,7 @@ added = p_map(partial(add, c='!'), l1, l2)
 All the parallel `p_tqdm` functions can be passed the keyword `num_cpus` to indicate how many CPUs to use. The default is all CPUs. `num_cpus` can either be an integer to indicate the exact number of CPUs to use or a float to indicate the proportion of CPUs to use.
 
 Note that the parallel Pool objects used by `p_tqdm` are automatically closed when the map finishes processing.
+
+### tqdm instance
+
+All the parallel `p_tqdm` functions can be passed the keyword `tqdm` to choose a specific flavor of tqdm. By default, this value is taken from `tqdm.auto`. The `tqdm` parameter can be used pass `p_tqdm` output to `tqdm.gui`, `tqdm.tk` or any customized subclass of `tqdm`.

--- a/p_tqdm/p_tqdm.py
+++ b/p_tqdm/p_tqdm.py
@@ -48,7 +48,10 @@ def _parallel(ordered: bool, function: Callable, *iterables: Iterable, **kwargs:
     pool = Pool(num_cpus)
     map_func = getattr(pool, map_type)
 
-    for item in tqdm(map_func(function, *iterables), total=length, **kwargs):
+    # Choose tqdm variant
+    tqdm_func = kwargs.pop('tqdm', tqdm)
+
+    for item in tqdm_func(map_func(function, *iterables), total=length, **kwargs):
         yield item
 
     pool.clear()


### PR DESCRIPTION
Added parameter to override tqdm to allow using `p_tqdm` with GUI progress bars.

tqdm flavors exist for tkinter and matplotlib, the following template could be used to feed progress bar values to any GUI toolkit:
```
class TqdmWrapper(tqdm.tqdm):
    def __init__(self, iterable, **kwargs):
        super().__init__(iterable=iterable, **kwargs)

    def display(self, msg=None, pos=None):
        print(self.format_dict)  # do something with self.format_dict['n']
```

Example for using with p_imap:
`iterator = p_tqdm.p_imap(add, ['1', '2', '3'], ['a', 'b', 'c'], tqdm=TqdmWrapper)`